### PR TITLE
[BAD-550] - add pentaho public repo to be able to resolve with empty repository

### DIFF
--- a/cdh57/pom.xml
+++ b/cdh57/pom.xml
@@ -593,4 +593,11 @@
             </plugin>-->
         </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>Pentaho Public Release Repo</id>
+            <url>http://nexus.pentaho.org/content/groups/omni</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
add link to public pentaho repository since if not filled with ant/ivy unable to resolve from public maven specific artifacts like kettle or other.