### PR TITLE
[BAD-577]-update impl/pom and shims/pom files

### DIFF
--- a/shims/emr46/impl/pom.xml
+++ b/shims/emr46/impl/pom.xml
@@ -23,8 +23,7 @@
     <org.mortbay.jetty.version>6.1.26</org.mortbay.jetty.version>
     <org.apache.htrace.version>3.1.0-incubating</org.apache.htrace.version>
     <org.apache.pig.version>0.14.0</org.apache.pig.version>
-    <org.apache.zookeeper.version>3.4.6</org.apache.zookeeper.version>
-    <org.apache.zookeeper2.version>3.4.8</org.apache.zookeeper2.version>
+    <org.apache.zookeeper.version>3.4.8</org.apache.zookeeper.version>
     <com.fasterxml.jackson.core.version>2.5.3</com.fasterxml.jackson.core.version>
     <org.apache.curator.version>2.7.1</org.apache.curator.version>
     <com.amazonaws.version>1.10.64</com.amazonaws.version>
@@ -212,18 +211,6 @@
       <artifactId>httpcore</artifactId>
       <version>${org.apache.httpcomponents.version}</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>dk.brics.automaton</groupId>
-      <artifactId>automaton</artifactId>
-      <version>${dk.brics.automaton.version}</version>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -1124,18 +1111,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
       <version>${io.netty2.version}</version>
@@ -1441,18 +1416,6 @@
       <artifactId>metrics-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper</artifactId>
-      <version>${org.apache.zookeeper2.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
       <version>${com.thoughtworks.xstream.version}</version>
@@ -1491,6 +1454,12 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/shims/mapr510/impl/pom.xml
+++ b/shims/mapr510/impl/pom.xml
@@ -809,6 +809,12 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -68,12 +68,6 @@
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Removed duplicated dependencies in impl/emr46/pom file:
 - automaton;
 - log4j;
 - zookeeper;
 - zookeeper2 version;

Updated impl/emr46/pom, impl/mapr510/pom files:
 - added exclusions to junit;

Updated impl/pom file:
 - removed exclusionf from junit dependency.