### PR TITLE
[BAD-577] Move the pentaho shims api dependency

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -105,10 +105,12 @@
     <dependency>
       <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
+      <version>${project.version}</version>      
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,18 +45,6 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>org.pentaho</groupId>
-        <artifactId>pentaho-hadoop-shims-api</artifactId>
-        <version>${dependency.hadoop-shims-api.revision}</version>
-        <classifier>tests</classifier>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.pentaho</groupId>
-        <artifactId>pentaho-hadoop-shims-api</artifactId>
-        <version>${dependency.hadoop-shims-api.revision}</version>
-      </dependency>
-      <dependency>
         <groupId>pentaho</groupId>
         <artifactId>oss-licenses</artifactId>
         <version>${dependency.oss-licenses.revision}</version>

--- a/shims/mapr510/assemblies/pentaho-hadoop-shims-mapr510-assemblies-reactor.iml
+++ b/shims/mapr510/assemblies/pentaho-hadoop-shims-mapr510-assemblies-reactor.iml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
Should not be in the root pom since api needs to build before this can be resolved.
As it was, the build was failing with a. QAT/Release version build.