### PR TITLE
[BACKLOG-13866]-add global excludes to both assembly sections

### DIFF
--- a/shims/cdh58/assemblies/client/src/assembly/assembly.xml
+++ b/shims/cdh58/assemblies/client/src/assembly/assembly.xml
@@ -29,9 +29,9 @@
         <exclude>junit:*</exclude>
         <exclude>commons-collections:commons-collections</exclude>
         <exclude>org.apache.zookeeper:zookeeper</exclude>
-        <exclude>*:tests:*</exclude>
         <exclude>com.google.guava:*</exclude>
         <exclude>xml-apis:xml-apis</exclude>
+        <exclude>*:tests:*</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>

--- a/shims/cdh58/assemblies/default/src/assembly/assembly.xml
+++ b/shims/cdh58/assemblies/default/src/assembly/assembly.xml
@@ -19,6 +19,28 @@
         <include>org.apache.sqoop:sqoop</include>
         <include>org.apache.pig:pig</include>
       </includes>
+      <excludes>
+        <exclude>log4j:log4j</exclude>
+        <exclude>org.mockito:mockito-all</exclude>
+        <exclude>junit:*</exclude>
+        <exclude>com.google.guava:*</exclude>
+        <exclude>xml-apis:xml-apis</exclude>
+        <exclude>commons-collections:commons-collections</exclude>
+        <exclude>org.apache.zookeeper:zookeeper</exclude>
+        <exclude>org.apache.hadoop:hadoop-annotations</exclude>
+        <exclude>org.apache.hadoop:hadoop-yarn-api</exclude>
+        <exclude>org.apache.hadoop:hadoop-yarn-common</exclude>
+        <exclude>org.apache.hadoop:hadoop-yarn-server-applicationhistoryservice</exclude>
+        <exclude>org.apache.hadoop:hadoop-yarn-server-common</exclude>
+        <exclude>org.apache.hadoop:hadoop-yarn-server-resourcemanager</exclude>
+        <exclude>org.apache.hadoop:hadoop-yarn-server-web-proxy</exclude>
+        <exclude>*:tests:*</exclude>
+        <!--hive-exec excludes-->
+        <exclude>*:logredactor:*</exclude>
+        <exclude>*:datanucleus-core:*</exclude>
+        <exclude>*:hbase-common:*</exclude>
+        <exclude>*:ST4:*</exclude>
+      </excludes>
     </dependencySet>
     <dependencySet>
       <outputDirectory>lib</outputDirectory>
@@ -48,6 +70,11 @@
         <exclude>org.apache.hadoop:hadoop-yarn-server-resourcemanager</exclude>
         <exclude>org.apache.hadoop:hadoop-yarn-server-web-proxy</exclude>
         <exclude>*:tests:*</exclude>
+        <!--hive-exec excludes-->
+        <exclude>*:logredactor:*</exclude>
+        <exclude>*:datanucleus-core:*</exclude>
+        <exclude>*:hbase-common:*</exclude>
+        <exclude>*:ST4:*</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>

--- a/shims/cdh58/impl/pom.xml
+++ b/shims/cdh58/impl/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>pentaho-hadoop-shims-cdh58-reactor</artifactId>
     <version>7.1-SNAPSHOT</version>
   </parent>
-  <artifactId>pentaho-hadoop-shims-cdh58-impl</artifactId>
+  <artifactId>pentaho-hadoop-shims-cdh58</artifactId>
   <packaging>jar</packaging>
   <version>7.1-SNAPSHOT</version>
   <properties>

--- a/shims/emr52/assemblies/client/src/assembly/assembly.xml
+++ b/shims/emr52/assemblies/client/src/assembly/assembly.xml
@@ -18,6 +18,7 @@
         <include>com.fasterxml.jackson.core:jackson-databind</include>
         <include>com.fasterxml.jackson.core:jackson-core</include>
         <include>com.fasterxml.jackson.core:jackson-annotations</include>
+        <include>org.codehaus.jackson:*</include>
         <include>org.jscience:jscience</include>
         <include>com.google.code.gson:gson</include>
         <include>org.apache.httpcomponents:httpclient</include>
@@ -27,6 +28,13 @@
         <include>commons-configuration:commons-configuration</include>
         <include>org.apache.commons:commons-exec</include>
       </includes>
+      <excludes>
+        <exclude>xml-apis:*</exclude>
+        <exclude>commons-collections:*</exclude>
+        <exclude>javax.xml.stream:*</exclude>
+        <exclude>org.apache.calcite:*</exclude>
+        <exclude>*:tests:*</exclude>
+      </excludes>
     </dependencySet>
     <dependencySet>
       <outputDirectory>lib/client</outputDirectory>
@@ -48,6 +56,8 @@
         <exclude>xml-apis:*</exclude>
         <exclude>*:stax-api:*</exclude>
         <exclude>commons-collections:*</exclude>
+        <exclude>javax.xml.stream:*</exclude>
+        <exclude>org.apache.calcite:*</exclude>
         <exclude>*:tests:*</exclude>
       </excludes>
     </dependencySet>

--- a/shims/emr52/assemblies/default/src/assembly/assembly.xml
+++ b/shims/emr52/assemblies/default/src/assembly/assembly.xml
@@ -26,6 +26,11 @@
         <include>pentaho:hadoop2-windows-patch</include>
         <include>commons-lang:commons-lang</include>
       </includes>
+      <excludes>
+        <exclude>javax.xml.stream:*</exclude>
+        <exclude>org.apache.calcite:*</exclude>
+        <exclude>*:tests:*</exclude>
+      </excludes>
     </dependencySet>
   </dependencySets>
 </assembly>

--- a/shims/emr52/client/pom.xml
+++ b/shims/emr52/client/pom.xml
@@ -89,6 +89,50 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <version>${org.codehaus.jackson}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>${org.codehaus.jackson}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-jaxrs</artifactId>
+      <version>${org.codehaus.jackson}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-xc</artifactId>
+      <version>${org.codehaus.jackson}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.jscience</groupId>
       <artifactId>jscience</artifactId>
       <version>${jscience.version}</version>

--- a/shims/emr52/impl/pom.xml
+++ b/shims/emr52/impl/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>pentaho-hadoop-shims-emr52-reactor</artifactId>
     <version>7.1-SNAPSHOT</version>
   </parent>
-  <artifactId>pentaho-hadoop-shims-emr52-impl</artifactId>
+  <artifactId>pentaho-hadoop-shims-emr52</artifactId>
   <packaging>jar</packaging>
   <version>7.1-SNAPSHOT</version>
   <dependencies>

--- a/shims/emr52/pom.xml
+++ b/shims/emr52/pom.xml
@@ -1,17 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.pentaho</groupId>
     <artifactId>pentaho-hadoop-shims-list</artifactId>
     <version>7.1-SNAPSHOT</version>
   </parent>
-
   <artifactId>pentaho-hadoop-shims-emr52-reactor</artifactId>
   <packaging>pom</packaging>
-
   <properties>
     <shim.name>emr52</shim.name>
     <joda-time.version>2.9.5</joda-time.version>
@@ -21,6 +17,7 @@
     <zookeeper.version>3.4.8</zookeeper.version>
     <com.amazonaws.version>1.10.75.1</com.amazonaws.version>
     <com.fasterxml.jackson.core.version>2.5.3</com.fasterxml.jackson.core.version>
+    <org.codehaus.jackson>1.9.13</org.codehaus.jackson>
     <commons-configuration.version>1.6</commons-configuration.version>
     <org.apache.httpcomponents.version>4.4</org.apache.httpcomponents.version>
     <jscience.version>4.3.1</jscience.version>
@@ -34,7 +31,6 @@
     <org.apache.hbase.version>1.2.3</org.apache.hbase.version>
     <xstream.version>1.4.4</xstream.version>
   </properties>
-
   <modules>
     <module>client</module>
     <module>pmr</module>

--- a/shims/hdi35/impl/pom.xml
+++ b/shims/hdi35/impl/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>pentaho-hadoop-shims-hdi35-reactor</artifactId>
     <version>7.1-SNAPSHOT</version>
   </parent>
-  <artifactId>pentaho-hadoop-shims-hdi35-impl</artifactId>
+  <artifactId>pentaho-hadoop-shims-hdi35</artifactId>
   <packaging>jar</packaging>
   <version>7.1-SNAPSHOT</version>
   <properties>

--- a/shims/hdp25/assemblies/default/src/assembly/assembly.xml
+++ b/shims/hdp25/assemblies/default/src/assembly/assembly.xml
@@ -22,6 +22,23 @@
         <include>org.codehaus.jackson:jackson-mapper-asl</include>
         <include>org.apache.avro:avro</include>
       </includes>
+      <excludes>
+        <exclude>log4j:log4j</exclude>
+        <exclude>xml-apis:xml-apis</exclude>
+        <exclude>commons-collections:*</exclude>
+        <exclude>xerces:xercesImpl</exclude>
+        <exclude>org.apache.hadoop:hadoop-annotations</exclude>
+        <exclude>org.apache.hadoop:hadoop-auth</exclude>
+        <exclude>org.apache.hadoop:hadoop-common</exclude>
+        <exclude>org.apache.hadoop:hadoop-yarn-api</exclude>
+        <exclude>org.apache.hadoop:hadoop-yarn-common</exclude>
+        <exclude>org.apache.hadoop:hadoop-yarn-registry</exclude>
+        <exclude>org.apache.hadoop:hadoop-yarn-server-common</exclude>
+        <exclude>org.apache.hadoop:hadoop-yarn-server-resourcemanager</exclude>
+        <exclude>org.apache.hadoop:hadoop-yarn-server-web-proxy</exclude>
+        <exclude>org.apache.hadoop:hadoop-hdfs</exclude>
+        <exclude>*:tests:*</exclude>
+      </excludes>
     </dependencySet>
     <dependencySet>
       <outputDirectory>lib</outputDirectory>

--- a/shims/hdp25/impl/pom.xml
+++ b/shims/hdp25/impl/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>pentaho-hadoop-shims-hdp25-reactor</artifactId>
     <version>7.1-SNAPSHOT</version>
   </parent>
-  <artifactId>pentaho-hadoop-shims-hdp25-impl</artifactId>
+  <artifactId>pentaho-hadoop-shims-hdp25</artifactId>
   <packaging>jar</packaging>
   <version>7.1-SNAPSHOT</version>
   <dependencies>

--- a/shims/mapr520/impl/pom.xml
+++ b/shims/mapr520/impl/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>pentaho-hadoop-shims-mapr520-reactor</artifactId>
     <version>7.1-SNAPSHOT</version>
   </parent>
-  <artifactId>pentaho-hadoop-shims-mapr520-impl</artifactId>
+  <artifactId>pentaho-hadoop-shims-mapr520</artifactId>
   <packaging>jar</packaging>
   <version>7.1-SNAPSHOT</version>
   <properties>


### PR DESCRIPTION
Added global excludes to both assembly sections.
Added exclusion of ST4 to cdh.
Added org.codehaus.jackson property and dependencies to client pom and assembly for emr.
