### PR TITLE
[BACKLOG-13866]-add com.fasterxml.jackson.core for cdh, add excludes

### DIFF
--- a/shims/cdh58/assemblies/client/src/assembly/assembly.xml
+++ b/shims/cdh58/assemblies/client/src/assembly/assembly.xml
@@ -9,6 +9,24 @@
     <dependencySet>
       <outputDirectory>lib/client</outputDirectory>
       <useTransitiveDependencies>true</useTransitiveDependencies>
+      <useTransitiveFiltering>false</useTransitiveFiltering>
+      <includes>
+        <include>com.fasterxml.jackson.core:jackson-databind</include>
+        <include>com.fasterxml.jackson.core:jackson-core</include>
+        <include>com.fasterxml.jackson.core:jackson-annotations</include>
+      </includes>
+      <excludes>
+        <exclude>junit:*</exclude>
+        <exclude>commons-collections:commons-collections</exclude>
+        <exclude>org.apache.zookeeper:zookeeper</exclude>
+        <exclude>com.google.guava:*</exclude>
+        <exclude>xml-apis:xml-apis</exclude>
+        <exclude>*:tests:*</exclude>
+      </excludes>
+    </dependencySet>
+    <dependencySet>
+      <outputDirectory>lib/client</outputDirectory>
+      <useTransitiveDependencies>true</useTransitiveDependencies>
       <useTransitiveFiltering>true</useTransitiveFiltering>
       <includes>
         <include>org.apache.hadoop:hadoop-client</include>

--- a/shims/cdh58/assemblies/default/src/assembly/assembly.xml
+++ b/shims/cdh58/assemblies/default/src/assembly/assembly.xml
@@ -35,6 +35,8 @@
         <exclude>org.apache.hadoop:hadoop-yarn-server-resourcemanager</exclude>
         <exclude>org.apache.hadoop:hadoop-yarn-server-web-proxy</exclude>
         <exclude>*:tests:*</exclude>
+        <exclude>*:hive-exec:*:core</exclude>
+        <exclude>org.apache.curator:apache-curator:pom</exclude>
         <!--hive-exec excludes-->
         <exclude>*:logredactor:*</exclude>
         <exclude>*:datanucleus-core:*</exclude>
@@ -69,7 +71,10 @@
         <exclude>org.apache.hadoop:hadoop-yarn-server-common</exclude>
         <exclude>org.apache.hadoop:hadoop-yarn-server-resourcemanager</exclude>
         <exclude>org.apache.hadoop:hadoop-yarn-server-web-proxy</exclude>
+        <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
         <exclude>*:tests:*</exclude>
+        <exclude>*:hive-exec:*:core</exclude>
+        <exclude>org.apache.curator:apache-curator:pom</exclude>
         <!--hive-exec excludes-->
         <exclude>*:logredactor:*</exclude>
         <exclude>*:datanucleus-core:*</exclude>

--- a/shims/cdh58/client/pom.xml
+++ b/shims/cdh58/client/pom.xml
@@ -82,5 +82,38 @@
       <artifactId>hadoop-yarn-server-web-proxy</artifactId>
       <version>${org.apache.hadoop.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${com.fasterxml.jackson.core.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${com.fasterxml.jackson.core.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${com.fasterxml.jackson.core.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 </project>

--- a/shims/cdh58/pom.xml
+++ b/shims/cdh58/pom.xml
@@ -20,6 +20,7 @@
     <org.apache.oozie.version>4.1.0-cdh5.8.0</org.apache.oozie.version>
     <hadoop2-windows-patch.version>08072014</hadoop2-windows-patch.version>
     <automaton.version>1.11-8</automaton.version>
+    <com.fasterxml.jackson.core.version>2.2.3</com.fasterxml.jackson.core.version>
   </properties>
   <modules>
     <module>client</module>


### PR DESCRIPTION
CDH updates:
 - added com.fasterxml.jackson.core to the clients pom and assembly;
 - added excludes of apache-curator.pom, hive-exec-core, jackson-databind to default.